### PR TITLE
Added Router.getMatchingRoutes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "preact-router",
+  "name": "preact-router-ssr",
   "amdName": "preactRouter",
-  "version": "2.5.7",
+  "version": "1.0.0",
   "description": "Connect your components up to that address bar.",
   "main": "dist/preact-router.js",
   "jsnext:main": "dist/preact-router.es.js",

--- a/src/util.js
+++ b/src/util.js
@@ -9,6 +9,17 @@ export function assign(obj, props) {
 	return obj;
 }
 
+export function getMatchingRoutes(routes, currentRoute) {
+	return routes
+		.slice()
+		.sort(pathRankSort)
+		.reduce((list, route) => {
+			let attrs = route.attributes || {};
+			let matches = exec(currentRoute, attrs.path, attrs);
+			return matches ? list.concat({ route, matches }) : list;
+		}, []);
+}
+
 export function exec(url, route, opts=EMPTY) {
 	let reg = /(?:\?([^#]*))?(#.*)?$/,
 		c = url.match(reg),

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,11 @@ describe('preact-router', () => {
 	});
 
 	describe('Router', () => {
+		it('should have static methods', () => {
+			expect(Router.getCurrentUrl).to.be.a('function');
+			expect(Router.getMatchingRoutes).to.be.a('function');
+		});
+
 		it('should filter children based on URL', () => {
 			let router = new Router({});
 			let children = [

--- a/test/util.js
+++ b/test/util.js
@@ -1,4 +1,4 @@
-import { exec, pathRankSort, segmentize, rank, strip } from 'src/util';
+import { exec, getMatchingRoutes, pathRankSort, rank, segmentize, strip } from 'src/util';
 
 describe('util', () => {
 	describe('strip', () => {
@@ -100,6 +100,54 @@ describe('util', () => {
 			expect(exec('/a', '/:foo+')).to.eql({ foo:'a' });
 			expect(exec('/a/b', '/:foo+')).to.eql({ foo:'a/b' });
 			expect(exec('/a/b/c', '/:foo+')).to.eql({ foo:'a/b/c' });
+		});
+	});
+
+	describe('getMatchingRoutes', () => {
+		const routeFactory =
+			(path, isDefault = false) => ({
+				attributes: {
+					path,
+					default: isDefault
+				}
+			});
+
+		it('should return default route when given url does not match any route', () => {
+			const defaultRoute = routeFactory('/base', true);
+			const routes = [
+				routeFactory('/foo'),
+				defaultRoute,
+				routeFactory('/bar'),
+				routeFactory('/baz')
+			];
+			expect(getMatchingRoutes(routes, '/quux')).to.eql([{ route:defaultRoute, matches:{} }]);
+		});
+
+		it('should return empty array when given url does not match any route (and no default route is defined)', () => {
+			const routes = [
+				routeFactory('/foo'),
+				routeFactory('/bar'),
+				routeFactory('/baz')
+			];
+			expect(getMatchingRoutes(routes, '/quux')).to.eql([]);
+		});
+
+		it('should return list of matching routes', () => {
+			const match1 = routeFactory('/bar/:bar');
+			const match2 = routeFactory('/bar/lol');
+			const routes = [
+				routeFactory('/foo'),
+				match1,
+				match2,
+				routeFactory('/baz')
+			];
+			expect(getMatchingRoutes(routes, '/bar/lol')).to.eql([{
+				route: match2,
+				matches: {}
+			}, {
+				route: match1,
+				matches: { bar:'lol' }
+			}]);
 		});
 	});
 });


### PR DESCRIPTION
**Commits:**
```
Added Router.getMatchingRoutes
Profit of Router.getMatchingRoutes for internals
```

**Motivation:**

Added a new `getMatchingRoutes` utility that encapsulates the logic to retrieve the child routes which matches a particular url.

```
interface IMatches {
  route: IChildRoute,
  matches: object
}

getMatchingRoutes(routes: IChildRoute[], currentRoute: string) : IMatches[]
```

This is utility is also useful to implement server side rendering.
The approach is based on this [react-router's example](https://reacttraining.com/react-router/web/guides/server-rendering/data-loading).
Let's see:

First client and server share the same utility to initialize a Redux store.

```js
// state.js
import { createStore, combineReducers } from 'redux';

export default initializeState =
  (initialState = {}) =>
    createStore(
      combineReducers({
        ...
      }),
      initialState
    );
```

The backend is based on expressjs. Let's keep things minimal for now:

```js
// main.js
import express from 'express';
import { h } from 'preact';

import renderToString from 'preact-render-to-string';

import initializeState from './state';
import buildInitialState from './state.server';
import App from './components/app';

const server = express();

server.get('*', async (req, res) => {
  const initialState = await buildInitialState(url, request);
  const store = initializeState(initialState);

  const html = renderToString(<App url={req.url} store={store} />);

  res.text(`<!doctype html><html><body>${html}<script> window.__PRELOADED_STATE__ = ${ JSON.stringify(store.getState()).replace(/</g, "\\u003c") };</script></body></html>`);
});
```

The last, and most important bit is `buildInitialState`, that permits to load server side the same redux store used on the client.
This is now possible thanks to `Router.getMatchingRoutes`.

```js
// state.server.js
import Router from 'preact-router';

const routes = [{
  attributes: {
    path: "/books"
  },
  data: {
    books: () => getBooks()
  }
}, {
  attributes: {
    path: "/book/:bookId"
  },
  data: {
    book: (params) => getBooks(params.bookId)
  }
}];

export default buildInitialState =
  async (url) => {
    const initialState = {};
    const routes = Router.getMatchingRoutes(routes, url);

    if (routes.length == 0){
      return initialState;
    }

    const { route, matches: params } = routes[0];

    const loaders = route.data;
    const loaderKeys = Object.keys(loaders);

    return (await Promise.all(loaderKeys.map((key) => loaders[key](params))))
      .reduce((state, value, i) => {
        const key = loaderKeys[i];
        state[key] = value;
        return state;
      }, initialState);
  }
```