### PR TITLE
feat: preventBubbling is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ render(
 
 `<Link>` is just a normal link, but it automatically adds and removes an "active" classname to itself based on whether it matches the current URL.
 
+By default Link allow bubbling event on click, but you can control it by prop `preventBubbling`.
+
 ```js
 import { Router } from 'preact-router';
 import { Link } from 'preact-router/match';
@@ -128,7 +130,7 @@ render(
     <nav>
       <Link activeClassName="active" href="/">Home</Link>
       <Link activeClassName="active" href="/foo">Foo</Link>
-      <Link activeClassName="active" href="/bar">Bar</Link>
+      <Link activeClassName="active" preventBubbling href="/bar">Click event will not bubble</Link>
     </nav>
     <Router>
       <div default>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,5 @@
 import * as preact from 'preact';
+import { LinkProps } from './match.d'
 
 export function route(url: string, replace?: boolean): boolean;
 export function route(options: { url: string; replace?: boolean }): boolean;
@@ -62,7 +63,7 @@ export function Route<Props>(
     props: RouteProps<Props> & Partial<Props>
 ): preact.VNode;
 
-export function Link(props: {activeClassName?: string} & JSX.HTMLAttributes): preact.VNode;
+export function Link(props: LinkProps): preact.VNode;
 
 declare module 'preact' {
     export interface Attributes extends RoutableProps {}

--- a/src/index.js
+++ b/src/index.js
@@ -89,10 +89,12 @@ function routeFromLink(node) {
 }
 
 
-function handleLinkClick(e) {
+function handleLinkClick(e, props) {
 	if (e.button==0) {
 		routeFromLink(e.currentTarget || e.target || this);
-		return prevent(e);
+
+		if (props.preventBubbling) return prevent(e);
+		return e;
 	}
 }
 
@@ -249,7 +251,7 @@ class Router extends Component {
 }
 
 const Link = (props) => (
-	createElement('a', assign({ onClick: handleLinkClick }, props))
+	createElement('a', assign({ onClick: e => handleLinkClick(e, props) }, props))
 );
 
 const Route = props => createElement(props.component, props);

--- a/src/match.d.ts
+++ b/src/match.d.ts
@@ -7,7 +7,8 @@ export class Match extends preact.Component<RoutableProps, {}> {
 }
 
 export interface LinkProps extends JSX.HTMLAttributes {
-    activeClassName: string;
+    activeClassName?: string;
+    preventBubbling?: boolean;
 }
 
 export function Link(props: LinkProps): preact.VNode;


### PR DESCRIPTION
Hi there!
I moved from react to preact and detect that my [`autoClose`-feature in Popup](https://github.com/apostololeg/sandbox-react/blob/0.0.5/src/components/UI/Popup/Popup.jsx#L62-L65) was broken. 
I discover that preact-router are preventing event bubbling when clicking on `<Link/>`.
I wonder to ask you – what prompted you to do this❓🙂

Anyway, I made this PR in case if you(like me) will decide to move this feature from default to optional.