### PR TITLE
Fix #253: Allow various native browser actions on <Link/> elements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,10 +90,9 @@ function routeFromLink(node) {
 
 
 function handleLinkClick(e) {
-	if (e.button==0) {
-		routeFromLink(e.currentTarget || e.target || this);
-		return prevent(e);
-	}
+	if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey || e.button!==0) return;
+	routeFromLink(e.currentTarget || e.target || this);
+	return prevent(e);
 }
 
 


### PR DESCRIPTION
This allows users to `SHIFT+click`, `ALT+click`, `CMD/CTRL+click`, `SHIFT+enter`, `ALT+enter` & `CMD/CTRL+enter` on a `<Link/>` with the expected behaviour.