### PR TITLE
Change activeClassName type definition

### DIFF
--- a/src/match.d.ts
+++ b/src/match.d.ts
@@ -7,7 +7,7 @@ export class Match extends preact.Component<RoutableProps, {}> {
 }
 
 export interface LinkProps extends preact.JSX.HTMLAttributes {
-    activeClassName: string;
+    activeClassName?: string;
     children?: preact.ComponentChildren;
 }
 


### PR DESCRIPTION
`activeClassName` is not always required.

https://github.com/preactjs/preact-router/blob/f7dbe6d07419aefb113a55d00af0436f7d9b8e15/src/match.js#L30
