### PR TITLE
Update information about react-router in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Connect your [Preact] components up to that address bar.
 
 > 💁 **Note:** This is not a preact-compatible version of React Router. `preact-router` is a simple URL wiring and does no orchestration for you.
 >
-> If you're looking for more complex solutions like nested routes and view composition, [react-router](https://github.com/ReactTraining/react-router) works great with preact as long as you alias in [preact-compat](https://github.com/developit/preact-compat).  React Router 4 even [works directly with Preact](https://codepen.io/developit/pen/BWxepY?editors=0010), no compatibility layer needed!
+> If you're looking for more complex solutions like nested routes and view composition, [react-router](https://github.com/ReactTraining/react-router) works great with preact as long as you alias in [preact/compat](https://preactjs.com/guide/v10/getting-started#aliasing-react-to-preact).
 
 #### [See a Real-world Example :arrow_right:](https://jsfiddle.net/developit/qc73v9va/)
 


### PR DESCRIPTION
- Point users to `preact/compat`
- `react-router` needs `preact/compat`, because we don't have a `default` export in Preact anymore.