### PR TITLE
Non standard native attribute change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Sometimes it's necessary to bypass preact-router's link handling and let the bro
 This can be accomplished by adding a `dataset-native` boolean attribute to any link:
 
 ```html
-<a href="/foo" dataset-native>Foo</a>
+<a href="/foo" data-native>Foo</a>
 ```
 
 ### Detecting Route Changes

--- a/README.md
+++ b/README.md
@@ -144,10 +144,10 @@ render(
 
 Sometimes it's necessary to bypass preact-router's link handling and let the browser perform routing on its own.
 
-This can be accomplished by adding a `native` boolean attribute to any link:
+This can be accomplished by adding a `dataset-native` boolean attribute to any link:
 
 ```html
-<a href="/foo" native>Foo</a>
+<a href="/foo" dataset-native>Foo</a>
 ```
 
 ### Detecting Route Changes

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ function delegateLinkHandler(e) {
 	let t = e.target;
 	do {
 		if (String(t.nodeName).toUpperCase()==='A' && t.getAttribute('href')) {
-			if (t.hasAttribute('dataset-native') || t.hasAttribute('native')) return;
+			if (t.hasAttribute('data-native') || t.hasAttribute('native')) return;
 			// if link is handled by the router, prevent browser defaults
 			if (routeFromLink(t)) {
 				return prevent(e);

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ function delegateLinkHandler(e) {
 	let t = e.target;
 	do {
 		if (String(t.nodeName).toUpperCase()==='A' && t.getAttribute('href')) {
-			if (t.hasAttribute('native')) return;
+			if (t.hasAttribute('dataset-native')) return;
 			// if link is handled by the router, prevent browser defaults
 			if (routeFromLink(t)) {
 				return prevent(e);

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ function delegateLinkHandler(e) {
 	let t = e.target;
 	do {
 		if (String(t.nodeName).toUpperCase()==='A' && t.getAttribute('href')) {
-			if (t.hasAttribute('dataset-native')) return;
+			if (t.hasAttribute('dataset-native') || t.hasAttribute('native')) return;
 			// if link is handled by the router, prevent browser defaults
 			if (routeFromLink(t)) {
 				return prevent(e);


### PR DESCRIPTION
Using native attribute in a tag is non standard.
This PR is about to use dataset-native instead of native attribute.
I may also note another PR : https://github.com/preactjs/preact/pull/2578