### PR TITLE
Add useRouter() hook and update Router.onChange

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,8 @@ export interface RouterOnChangeArgs {
     previous?: string;
     active: preact.VNode[];
     current: preact.VNode;
+    path: string | null;
+    matches: Record<string, string> | null;
 }
 
 export interface RouterProps extends RoutableProps {
@@ -63,6 +65,8 @@ export function Route<Props>(
 ): preact.VNode;
 
 export function Link(props: {activeClassName?: string} & preact.JSX.HTMLAttributes): preact.VNode;
+
+export function useRouter(): [((url: string, replace?: boolean) => boolean) | ((options: { url: string; replace?: boolean }) => boolean), RouterOnChangeArgs];
 
 declare module 'preact' {
     export interface Attributes extends RoutableProps {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ export interface RoutableProps {
     default?: boolean;
 }
 
-export interface RouterOnChangeArgs<RouteParams extends Record<string, string> | null = Record<string, string> | null> {
+export interface RouterOnChangeArgs<RouteParams extends Record<string, string | undefined> | null = Record<string, string | undefined> | null> {
     router: Router;
     url: string;
     previous?: string;
@@ -32,7 +32,7 @@ export interface RouterOnChangeArgs<RouteParams extends Record<string, string> |
     matches: RouteParams;
 }
 
-export interface RouterProps<RouteParams extends Record<string, string> | null = Record<string, string> | null> extends RoutableProps {
+export interface RouterProps<RouteParams extends Record<string, string | undefined> | null = Record<string, string | undefined> | null> extends RoutableProps {
     history?: CustomHistory;
     static?: boolean;
     url?: string;
@@ -66,7 +66,7 @@ export function Route<Props>(
 
 export function Link(props: {activeClassName?: string} & preact.JSX.HTMLAttributes): preact.VNode;
 
-export function useRouter<RouteParams extends Record<string, string> | null = Record<string, string> | null>(): [
+export function useRouter<RouteParams extends Record<string, string | undefined> | null = Record<string, string | undefined> | null>(): [
     RouterOnChangeArgs<RouteParams>,
     (urlOrOptions: string | { url: string; replace?: boolean }, replace?: boolean) => boolean,
 ];

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,7 +68,7 @@ export function Link(props: {activeClassName?: string} & preact.JSX.HTMLAttribut
 
 export function useRouter(): [
     RouterOnChangeArgs,
-    ((url: string, replace?: boolean) => boolean) | ((options: { url: string; replace?: boolean }) => boolean),
+    (urlOrOptions: string | { url: string; replace?: boolean }, replace?: boolean) => boolean,
 ];
 
 declare module 'preact' {

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,8 +50,6 @@ export class Router extends preact.Component<RouterProps, {}> {
     render(props: RouterProps, {}): preact.VNode;
 }
 
-export const subscribers: Array<(url: string) => void>
-
 type AnyComponent<Props> =
   | preact.FunctionalComponent<Props>
   | preact.ComponentConstructor<Props, any>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,7 +66,10 @@ export function Route<Props>(
 
 export function Link(props: {activeClassName?: string} & preact.JSX.HTMLAttributes): preact.VNode;
 
-export function useRouter(): [((url: string, replace?: boolean) => boolean) | ((options: { url: string; replace?: boolean }) => boolean), RouterOnChangeArgs];
+export function useRouter(): [
+    RouterOnChangeArgs,
+    ((url: string, replace?: boolean) => boolean) | ((options: { url: string; replace?: boolean }) => boolean),
+];
 
 declare module 'preact' {
     export interface Attributes extends RoutableProps {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,21 +22,22 @@ export interface RoutableProps {
     default?: boolean;
 }
 
-export interface RouterOnChangeArgs {
+export type RouteParamDefault = Record<string, string> | null;
+export interface RouterOnChangeArgs<RouteParams extends RouteParamDefault = RouteParamDefault> {
     router: Router;
     url: string;
     previous?: string;
     active: preact.VNode[];
     current: preact.VNode;
     path: string | null;
-    matches: Record<string, string> | null;
+    matches: RouteParams;
 }
 
-export interface RouterProps extends RoutableProps {
+export interface RouterProps<RouteParams extends RouteParamDefault = RouteParamDefault> extends RoutableProps {
     history?: CustomHistory;
     static?: boolean;
     url?: string;
-    onChange?: (args: RouterOnChangeArgs) => void;
+    onChange?: (args: RouterOnChangeArgs<RouteParams>) => void;
 }
 
 export class Router extends preact.Component<RouterProps, {}> {
@@ -66,8 +67,8 @@ export function Route<Props>(
 
 export function Link(props: {activeClassName?: string} & preact.JSX.HTMLAttributes): preact.VNode;
 
-export function useRouter(): [
-    RouterOnChangeArgs,
+export function useRouter<RouteParams extends RouteParamDefault = RouteParamDefault>(): [
+    RouterOnChangeArgs<RouteParams>,
     (urlOrOptions: string | { url: string; replace?: boolean }, replace?: boolean) => boolean,
 ];
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,8 +22,7 @@ export interface RoutableProps {
     default?: boolean;
 }
 
-export type RouteParamDefault = Record<string, string> | null;
-export interface RouterOnChangeArgs<RouteParams extends RouteParamDefault = RouteParamDefault> {
+export interface RouterOnChangeArgs<RouteParams extends Record<string, string> | null = Record<string, string> | null> {
     router: Router;
     url: string;
     previous?: string;
@@ -33,7 +32,7 @@ export interface RouterOnChangeArgs<RouteParams extends RouteParamDefault = Rout
     matches: RouteParams;
 }
 
-export interface RouterProps<RouteParams extends RouteParamDefault = RouteParamDefault> extends RoutableProps {
+export interface RouterProps<RouteParams extends Record<string, string> | null = Record<string, string> | null> extends RoutableProps {
     history?: CustomHistory;
     static?: boolean;
     url?: string;
@@ -67,7 +66,7 @@ export function Route<Props>(
 
 export function Link(props: {activeClassName?: string} & preact.JSX.HTMLAttributes): preact.VNode;
 
-export function useRouter<RouteParams extends RouteParamDefault = RouteParamDefault>(): [
+export function useRouter<RouteParams extends Record<string, string> | null = Record<string, string> | null>(): [
     RouterOnChangeArgs<RouteParams>,
     (urlOrOptions: string | { url: string; replace?: boolean }, replace?: boolean) => boolean,
 ];

--- a/match/src/index.js
+++ b/match/src/index.js
@@ -1,39 +1,22 @@
-import { h, Component } from 'preact';
-import { subscribers, getCurrentUrl, Link as StaticLink, exec } from 'preact-router';
+import { h } from 'preact';
+import { Link as StaticLink, exec, useRouter } from 'preact-router';
 
-export class Match extends Component {
-	componentDidMount() {
-		this.update = url => {
-			this.nextUrl = url;
-			this.setState({});
-		};
-		subscribers.push(this.update);
-	}
-	componentWillUnmount() {
-		subscribers.splice(subscribers.indexOf(this.update)>>>0, 1);
-	}
-	render(props) {
-		let url = this.nextUrl || getCurrentUrl(),
-			path = url.replace(/\?.+$/,'');
-		this.nextUrl = null;
-		return props.children({
-			url,
-			path,
-			matches: exec(path, props.path, {}) !== false
-		});
-	}
+export function Match(props) {
+	const [{ url, path }] = useRouter();
+	return props.children({
+		url,
+		path,
+		matches: !!url && !!path && exec(path, props.path, {}) !== false
+	});
 }
 
-export function Link({ class: c, className, activeClass, activeClassName, path, ...props }) {
+export function Link({ class: c, className, activeClass, activeClassName, path: linkPath, ...props }) {
 	const inactive = [c, className].filter(Boolean).join(' ');
 	const active = [c, className, activeClass, activeClassName].filter(Boolean).join(' ');
-	return (
-		<Match path={path || props.href}>
-			{ ({ matches }) => (
-				<StaticLink {...props} class={matches ? active : inactive} />
-			) }
-		</Match>
-	);
+	const path = useRouter()[0].path || props.href;
+	const matches = !!path && exec(path, linkPath, {}) !== false;
+
+	return <StaticLink {...props} class={matches ? active : inactive} />
 }
 
 export default Match;

--- a/src/cjs.js
+++ b/src/cjs.js
@@ -1,6 +1,5 @@
-import { subscribers, getCurrentUrl, route, Router, Route, Link, exec, useRouter } from './index';
+import { getCurrentUrl, route, Router, Route, Link, exec, useRouter } from './index';
 
-Router.subscribers = subscribers;
 Router.getCurrentUrl = getCurrentUrl;
 Router.route = route;
 Router.Router = Router;

--- a/src/cjs.js
+++ b/src/cjs.js
@@ -1,4 +1,4 @@
-import { subscribers, getCurrentUrl, route, Router, Route, Link, exec } from './index';
+import { subscribers, getCurrentUrl, route, Router, Route, Link, exec, useRouter } from './index';
 
 Router.subscribers = subscribers;
 Router.getCurrentUrl = getCurrentUrl;
@@ -7,5 +7,6 @@ Router.Router = Router;
 Router.Route = Route;
 Router.Link = Link;
 Router.exec = exec;
+Router.useRouter = useRouter;
 
 export default Router;

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,6 @@ let customHistory = null;
 
 const ROUTERS = [];
 
-const subscribers = [];
-
 const EMPTY = {};
 
 function useRouter() {
@@ -73,9 +71,6 @@ function routeTo(url) {
 		if (ROUTERS[i].routeTo(url)===true) {
 			didRoute = true;
 		}
-	}
-	for (let i=subscribers.length; i--; ) {
-		subscribers[i](url);
 	}
 	return didRoute;
 }
@@ -271,5 +266,5 @@ const Link = (props) => (
 
 const Route = props => createElement(props.component, props);
 
-export { subscribers, getCurrentUrl, route, Router, Route, Link, exec, useRouter };
+export { getCurrentUrl, route, Router, Route, Link, exec, useRouter };
 export default Router;

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const subscribers = [];
 const EMPTY = {};
 
 function useRouter() {
-	return [route, useContext(RouterContext)];
+	return [useContext(RouterContext), route];
 }
 
 function setUrl(url, type='push') {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
-import { cloneElement, createElement, Component, toChildArray } from 'preact';
+import { h, cloneElement, createElement, Component, toChildArray, createContext } from 'preact';
+import { useContext } from 'preact/hooks';
 import { exec, prepareVNodeForRanking, assign, pathRankSort } from './util';
+
+const RouterContext = createContext({});
 
 let customHistory = null;
 
@@ -9,12 +12,16 @@ const subscribers = [];
 
 const EMPTY = {};
 
+function useRouter() {
+	return [route, useContext(RouterContext)];
+}
+
 function setUrl(url, type='push') {
 	if (customHistory && customHistory[type]) {
 		customHistory[type](url);
 	}
-	else if (typeof history!=='undefined' && history[type+'State']) {
-		history[type+'State'](null, null, url);
+	else if (typeof history!=='undefined' && history[`${type}State`]) {
+		history[`${type}State`](null, null, url);
 	}
 }
 
@@ -150,6 +157,7 @@ class Router extends Component {
 		this.state = {
 			url: props.url || getCurrentUrl()
 		};
+		this.contextValue = {};
 
 		initEventListeners();
 	}
@@ -216,9 +224,13 @@ class Router extends Component {
 						assign(newProps, matches);
 						delete newProps.ref;
 						delete newProps.key;
-						return cloneElement(vnode, newProps);
+						return {
+							vnode: cloneElement(vnode, newProps),
+							matches
+						};
 					}
-					return vnode;
+
+					return { vnode, matches };
 				}
 			}).filter(Boolean);
 	}
@@ -226,23 +238,30 @@ class Router extends Component {
 	render({ children, onChange }, { url }) {
 		let active = this.getMatchingChildren(toChildArray(children), url, true);
 
-		let current = active[0] || null;
+		let { vnode: current, matches } = active[0] || { vnode: null, matches: null };
 
 		let previous = this.previousUrl;
 		if (url!==previous) {
 			this.previousUrl = url;
+			this.contextValue = {
+				router: this,
+				url,
+				previous,
+				active: active.map(a => a.vnode),
+				current,
+				path: current ? current.props.path : null,
+				matches
+			};
 			if (typeof onChange==='function') {
-				onChange({
-					router: this,
-					url,
-					previous,
-					active,
-					current
-				});
+				onChange(this.contextValue);
 			}
 		}
 
-		return current;
+		return (
+			<RouterContext.Provider value={this.contextValue}>
+				{current}
+			</RouterContext.Provider>
+		);
 	}
 }
 
@@ -252,5 +271,5 @@ const Link = (props) => (
 
 const Route = props => createElement(props.component, props);
 
-export { subscribers, getCurrentUrl, route, Router, Route, Link, exec };
+export { subscribers, getCurrentUrl, route, Router, Route, Link, exec, useRouter };
 export default Router;

--- a/test/dist.test.js
+++ b/test/dist.test.js
@@ -33,15 +33,15 @@ describe('dist', () => {
 			let router = new Router({});
 
 			expect(
-				router.render({ children }, { url:'/foo' })
+				router.render({ children }, { url:'/foo' }).props.children
 			).toBeCloneOf(children[1], { url: '/foo' });
 
 			expect(
-				router.render({ children }, { url:'/' })
+				router.render({ children }, { url:'/' }).props.children
 			).toBeCloneOf(children[0]);
 
 			expect(
-				router.render({ children }, { url:'/foo/bar' })
+				router.render({ children }, { url:'/foo/bar' }).props.children
 			).toBeCloneOf(children[2]);
 		});
 	});

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -1,4 +1,4 @@
-import { Router, Link, route } from 'preact-router';
+import { Router, Link, route, Route } from 'preact-router';
 import { Match, Link as ActiveLink } from '../match/src';
 import { h, render } from 'preact';
 import { act } from 'preact/test-utils';
@@ -201,12 +201,20 @@ describe('dom', () => {
 					spy2 = jasmine.createSpy('spy2'),
 					spy3 = jasmine.createSpy('spy3');
 
+				const components = () => [
+					<Match key="match-1" path="/foo">{spy1}</Match>,
+					<Match key="match-2" path="/bar">{spy2}</Match>,
+					<Match key="match-3" path="/bar/:param">{spy3}</Match>,
+				];
 				mount(
 					<div>
-						<Router />
-						<Match path="/foo">{spy1}</Match>
-						<Match path="/bar">{spy2}</Match>
-						<Match path="/bar/:param">{spy3}</Match>
+						<Router>
+							<Route path="/" component={components} />
+							<Route path="/foo" component={components} />
+							<Route path="/bar" component={components} />
+							<Route path="/bar/:param" component={components} />
+							<Route default component={components} />
+						</Router>
 					</div>
 				);
 
@@ -263,19 +271,26 @@ describe('dom', () => {
 
 				await sleep(10);
 
-				expect(spy1).withContext('spy1 /bar/123').toHaveBeenCalledWith(jasmine.objectContaining({ matches: false, path:'/bar/123', url:'/bar/123' }));
-				expect(spy2).withContext('spy2 /bar/123').toHaveBeenCalledWith(jasmine.objectContaining({ matches: false, path:'/bar/123', url:'/bar/123' }));
-				expect(spy3).withContext('spy3 /bar/123').toHaveBeenCalledWith(jasmine.objectContaining({ matches: true, path:'/bar/123', url:'/bar/123' }));
+				expect(spy1).withContext('spy1 /bar/123').toHaveBeenCalledWith(jasmine.objectContaining({ matches: false, path:'/bar/:param', url:'/bar/123' }));
+				expect(spy2).withContext('spy2 /bar/123').toHaveBeenCalledWith(jasmine.objectContaining({ matches: false, path:'/bar/:param', url:'/bar/123' }));
+				expect(spy3).withContext('spy3 /bar/123').toHaveBeenCalledWith(jasmine.objectContaining({ matches: true, path:'/bar/:param', url:'/bar/123' }));
 			});
 		});
 
 		describe('<Link>', () => {
 			it('should render with active class when active', async () => {
+				const components = () => [
+					<ActiveLink key="link-1" activeClassName="active" path="/foo">foo</ActiveLink>,
+					<ActiveLink key="link-2" activeClassName="active" class="bar" path="/bar">bar</ActiveLink>,
+				];
+
 				mount(
 					<div>
-						<Router />
-						<ActiveLink activeClassName="active" path="/foo">foo</ActiveLink>
-						<ActiveLink activeClassName="active" class="bar" path="/bar">bar</ActiveLink>
+						<Router>
+							<Route path="/foo" component={components} />
+							<Route path="/bar" component={components} />
+							<Route default component={components} />
+						</Router>
 					</div>
 				);
 				route('/foo');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -188,6 +188,40 @@ describe('preact-router', () => {
 
 			router.componentWillUnmount();
 		});
+
+		it('should send proper params to Router.onChange', () => {
+			let onChange = jasmine.createSpy('onChange');
+
+			let children = [
+				<index path="/" />,
+				<foo path="/foo/:id" />,
+				<bar path="/bar/:baz/boo/:bibi" />
+			];
+
+			render(
+				(
+					<Router onChange={onChange} ref={ref => (router = ref)}>
+						{children}
+					</Router>
+				),
+				scratch
+			);
+
+			router.render(router.props, { url: '/' });
+			expect(onChange).toHaveBeenCalledWith(
+				jasmine.objectContaining({ path: '/' })
+			)
+
+			router.render(router.props, { url: '/foo/67' });
+			expect(onChange).toHaveBeenCalledWith(
+				jasmine.objectContaining({ path: '/foo/:id' })
+			)
+
+			router.render(router.props, { url: '/bar/bazparam/boo/bibiparam' });
+			expect(onChange).toHaveBeenCalledWith(
+				jasmine.objectContaining({ path: '/bar/:baz/boo/:bibi' })
+			)
+		})
 	});
 
 	describe('route()', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -288,7 +288,7 @@ describe('preact-router', () => {
 		let router;
 
 		it('should return route() as first param', () => {
-			const [routeFromHook] = useRouter()
+			const [, routeFromHook] = useRouter()
 			expect(routeFromHook).toBeInstanceOf(Function)
 			expect(routeFromHook).toBe(route)
 		})
@@ -299,7 +299,6 @@ describe('preact-router', () => {
 
 			const FunctionalComponent = ({ path, shouldMatch }) => {
 				const [
-					,
 					{
 						router: routerFromHook,
 						url,

--- a/test/router.tsx
+++ b/test/router.tsx
@@ -49,6 +49,13 @@ function UseRouterFn() {
         route
     ] = useRouter()
 
+    const [
+        {
+            matches: typedMatches,
+        }
+    ] = useRouter<{id: string}>()
+    const id = typedMatches.id
+
     route('/foo')
     route({ url: '/bar', replace: true })
 }

--- a/test/router.tsx
+++ b/test/router.tsx
@@ -1,5 +1,5 @@
 import { h, render, Component, FunctionalComponent } from 'preact';
-import Router, { Route, RoutableProps } from '../';
+import Router, { Route, RoutableProps, useRouter } from '../';
 
 class ClassComponent extends Component<{}, {}> {
     render() {
@@ -33,4 +33,22 @@ function RouterWithRoutes() {
             <Route path="/b" component={SomeFunctionalComponent} />
         </Router>
     );
+}
+
+function UseRouterFn() {
+    const [
+        {
+            active,
+            current,
+            matches,
+            path,
+            router,
+            url,
+            previous
+        },
+        route
+    ] = useRouter()
+
+    route('/foo')
+    route({ url: '/bar', replace: true })
 }

--- a/test/utils/assert-clone-of.js
+++ b/test/utils/assert-clone-of.js
@@ -20,7 +20,7 @@ function serialize(vnode, prefix = '') {
 	for (let prop in vnode.props) {
 		const v = vnode.props[prop];
 		if (prop === 'children') {
-			children = toChildArray(v).reduce((str, v) => `${str}\n${serialize(v, prefix + '  ')}`, '')
+			children = toChildArray(v).reduce((str, v) => `${str}\n${serialize(v, `${prefix  }  `)}`, '')
 		}
 		else {
 			str += ` ${prop}=${JSON.stringify(v)}`;


### PR DESCRIPTION
Fixes #339

This PR adds the `useRouter()` hook that leverage preact `useContext()`.

Usage:
```
const [
    {
        router,
        url,
        previous,
        active,
        current,
        path,
        matches
    },
    route,
] = useRouter()
```

This PR also adds `path` and `matches` to the `onChange` Router callback.