### PR TITLE
Proposal: unmatched optional path segments should be `undefined` in props

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -30,12 +30,12 @@ export function exec(url, route, opts) {
 				flags = (route[i].match(/[+*?]+$/) || EMPTY)[0] || '',
 				plus = ~flags.indexOf('+'),
 				star = ~flags.indexOf('*'),
-				val = url[i] || '';
+				val = url[i];
 			if (!val && !star && (flags.indexOf('?')<0 || plus)) {
 				ret = false;
 				break;
 			}
-			matches[param] = decodeURIComponent(val);
+			matches[param] = val && decodeURIComponent(val);
 			if (plus || star) {
 				matches[param] = url.slice(i).map(decodeURIComponent).join('/');
 				break;


### PR DESCRIPTION
Currently, optional path segments that do not match a current URL produce same-named props with an empty string value:

```js
exec('/posts', '/posts/:user?/:id?', {})
// { user: "", id: "" }

exec('/posts/bob', '/posts/:user?/:id?', {})
// { user: "bob", id: "" }
```

With this PR, the value for optional path segments that have no match is an empty string. Matched path segments that are empty will still produce an empty string.

```js
exec('/posts', '/posts/:user?/:id?', {})
// { user: undefined, id: undefined }

exec('/posts/bob', '/posts/:user?/:id?', {})
// { user: "bob", id: undefined }
```

This is a major change, because it means any `defaultProps` for route components _will_ be applied for empty/missing route parameters - currently they are not.

Fixes #381.