### PR TITLE
Cheking urls considering protocol-relative url

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ function routeFromLink(node) {
 		target = node.getAttribute('target');
 
 	// ignore links with targets and non-path URLs
-	if (!href || !href.match(/^\//g) || (target && !target.match(/^_?self$/i))) return;
+	if (!href || !href.match(/^\/(?!\/)/g) || (target && !target.match(/^_?self$/i))) return;
 
 	// attempt to route, if no match simply cede control to browser
 	return route(href);


### PR DESCRIPTION
When using the <Router> only in a specific part of the web page, in other parts, they may not know that they should add a _native_ boolean attribute to a link tag for bypassing preact-router's link handling.

Currently, in this case, if the protocol-relative is used to the value of href, the link can't avoid handling of preact-router because it starts with '/'.

So i suggest modifying the regex.
From: If the value of href start '/'
To: If the value of href start with '/' but the next character is not '/'