### PR TITLE
docs(readme): Note added for history v5's types

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ const Main = () => (
 render(<Main />, document.body);
 ```
 
+Note: As of `history` v5.0.0, the TypeScript types are incompatible with `preact-router`. Downgrade to v4.x.x to maintain compatability. 
+
 ### Programmatically Triggering Route
 
 It's possible to programmatically trigger a route to a page (like `window.location = '/page-2'`)


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Expounding upon documentation

**Summary**
#385 brought up `history` v5's types being incompatible with `preact-router`'s. If a new user were to read the [custom history section](https://github.com/preactjs/preact-router#custom-history) and use the latest version of `history` along with TypeScript then they would not be able to build their application.

I figure that adding a note is a simple and quick temporary solution for anyone else who comes across this. Let me know if I should change the verbiage in any way. 