### PR TITLE
docs(readme): Correcting TravisCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # preact-router
 
 [![NPM](https://img.shields.io/npm/v/preact-router.svg)](https://www.npmjs.com/package/preact-router)
-[![travis-ci](https://travis-ci.org/developit/preact-router.svg)](https://travis-ci.org/developit/preact-router)
+[![travis-ci](https://travis-ci.org/preactjs/preact-router.svg)](https://travis-ci.org/preactjs/preact-router)
 
 Connect your [Preact] components up to that address bar.
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Documentation fix

**Summary**
The TravisCI badge currently points to `developit/preact-router`, not `preactjs/preact-router`. This results in a build status of "unknown" and no working link to the CI build.

This PR simply corrects the SVG & the external link to Travis