### PR TITLE
fix: TS types on Router children components

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,9 @@ export function Route<Props>(
 export function Link(props: {activeClassName?: string} & preact.JSX.HTMLAttributes): preact.VNode;
 
 declare module 'preact' {
-    export interface Attributes extends RoutableProps {}
+    namespace JSX {
+        interface IntrinsicAttributes extends RoutableProps {}
+    }
 }
 
 export default Router;


### PR DESCRIPTION
This PR is a correction to the types when using components in place of the `Route` component as children of `Router`.

The best way to demonstrate the issue is to create a new project using Preact-CLI's Typescript template. All routes come in this style:

```
const x: FunctionalComponent = () => { ... }
```

...as this is the only style that worked for the typings before this PR. Take away the type annotation or swap the const function for a simple function (`function x() { ... }`) and TS would infer the types of these to be of `JSXInternal.Element`. The solution here only affects `Attributes` while the inferred type needs `IntrinsicAttributes` to be affected in order to be functional on all components.

With this change, the following becomes viable once more:

```
function Home() { ... }

function App() {
  return (
    <Router>
      <Home path="/" />
    </Router>  
  );
}
```

Without, `path` (and `default`, as the other property of `RoutableProps`) would be an error in `noImplicitAny`/`strict` TS.