### PR TITLE
Update Travis CI badge to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # preact-router
 
 [![NPM](https://img.shields.io/npm/v/preact-router.svg)](https://www.npmjs.com/package/preact-router)
-[![travis-ci](https://travis-ci.org/developit/preact-router.svg)](https://travis-ci.org/developit/preact-router)
+[![Build status](https://github.com/preactjs/preact-router/actions/workflows/node.js.yml/badge.svg)](https://github.com/preactjs/preact-router/actions/workflows/node.js.yml)
 
 Connect your [Preact](https://github.com/preactjs/preact) components up to that address bar.
 


### PR DESCRIPTION
This project hasn't been using Travis CI for a long time, but the README still
shows the old Travis CI badge which currently shows build status as "unknown".

This implements my earlier suggestion on the original PR to migrate from Travis
CI to GitHub Actions: https://github.com/preactjs/preact-router/pull/397 .