### PR TITLE
Add support for `activeClassName` and `activeClass`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ render(
 );
 ```
 
-`<Link>` is just a normal link, but it automatically adds and removes an "active" classname to itself based on whether it matches the current URL. You can use either `activeClassName` or `activeClass` properties for active classes.
+`<Link>` is just a normal link, but it automatically adds and removes an "active" classname to itself based on whether it matches the current URL.
 
 ```js
 import { Router } from 'preact-router';

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ render(
 );
 ```
 
-`<Link>` is just a normal link, but it automatically adds and removes an "active" classname to itself based on whether it matches the current URL.
+`<Link>` is just a normal link, but it automatically adds and removes an "active" classname to itself based on whether it matches the current URL. You can use either `activeClassName` or `activeClass` properties for active classes.
 
 ```js
 import { Router } from 'preact-router';

--- a/index.d.ts
+++ b/index.d.ts
@@ -73,7 +73,7 @@ export function Route<Props>(
 ): preact.VNode;
 
 export function Link(
-	props: { activeClassName?: string } & preact.JSX.HTMLAttributes
+	props: { activeClassName?: string, activeClass?: string } & preact.JSX.HTMLAttributes
 ): preact.VNode;
 
 export function useRouter<

--- a/src/index.js
+++ b/src/index.js
@@ -268,7 +268,16 @@ assign(RouterProto, {
 	}
 });
 
-const Link = props => h('a', assign({ onClick: delegateLinkHandler }, props));
+const Link = props => {
+	const linkIsActive = getCurrentUrl() === props.href;
+
+	// We don't need activeclassname attribute in DOM elements and we'll re-add className
+	const { className, class: rawClass, activeClassName, activeClass, ...propsWithoutClass } = props;
+
+	propsWithoutClass.className = `${className || rawClass} ${linkIsActive ? activeClassName || activeClass : ""}`;
+
+	return h('a', assign({ onClick: delegateLinkHandler }, propsWithoutClass));
+};
 
 const Route = props => h(props.component, props);
 

--- a/src/index.js
+++ b/src/index.js
@@ -274,7 +274,7 @@ const Link = props => {
 	// We don't need activeclassname attribute in DOM elements and we'll re-add className
 	const { className, class: rawClass, activeClassName, activeClass, ...propsWithoutClass } = props;
 
-	propsWithoutClass.className = `${className || rawClass} ${linkIsActive ? activeClassName || activeClass : ""}`;
+	propsWithoutClass.className = `${className || rawClass || ""} ${linkIsActive ? activeClassName || activeClass : ""}`;
 
 	return h('a', assign({ onClick: delegateLinkHandler }, propsWithoutClass));
 };


### PR DESCRIPTION
This fixes "activeClassName" not being added when `<Link>`'s `href` property and current URL match, as well as adds "activeClass" property.

I am not sure whether "activeClass" should be documented in README or anywhere else.