### PR TITLE
Add types to the Match function 

### DIFF
--- a/match/index.d.ts
+++ b/match/index.d.ts
@@ -2,7 +2,17 @@ import * as preact from 'preact';
 
 import { Link as StaticLink, RoutableProps } from '..';
 
-export class Match extends preact.Component<RoutableProps, {}> {
+type MatchInfo = {
+	url: string;
+	path: string;
+	matches: Record<string, string>;
+};
+
+type MatchProps = RoutableProps & {
+	children: (info: MatchInfo) => preact.VNode;
+};
+
+export class Match extends preact.Component<MatchProps, {}> {
 	render(): preact.VNode;
 }
 

--- a/match/index.d.ts
+++ b/match/index.d.ts
@@ -1,6 +1,6 @@
 import * as preact from 'preact';
 
-import { Link as StaticLink, RoutableProps } from '..';
+import { RoutableProps } from '..';
 
 type MatchInfo = {
 	url: string;

--- a/test/match.tsx
+++ b/test/match.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { Link, RoutableProps } from '../';
+import { Link } from '../';
 import { Match } from '../match';
 
 function ChildComponent({}: {}) {


### PR DESCRIPTION
When using `preact-router` with TypeScript (and strict settings) you had to explicitly type the function passed as a child to the Match component like this:
```js
<Match path="/">{({ url }: {url: string}) => <pre>{url}</pre>}</Match>
```

This PR overrides the type of the children property of the Match component to provide the required types. I also removed unused imports in `match/index.d.ts` and `test/match.tsx`.