### PR TITLE
Fix exports map to support loading in Node esm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 /npm-debug.log
 .DS_Store
 /match/*.js
+/match/*.mjs

--- a/package.json
+++ b/package.json
@@ -4,26 +4,26 @@
 	"version": "4.0.1",
 	"description": "Connect your components up to that address bar.",
 	"main": "dist/preact-router.js",
-	"module": "dist/preact-router.mjs",
-	"jsnext:main": "dist/preact-router.mjs",
+	"module": "dist/preact-router.module.js",
+	"jsnext:main": "dist/preact-router.module.js",
 	"umd:main": "dist/preact-router.umd.js",
 	"unpkg": "dist/preact-router.umd.js",
 	"exports": {
 		".": {
-			"module": "./dist/preact-router.mjs",
+			"module": "./dist/preact-router.module.js",
 			"import": "./dist/preact-router.mjs",
 			"require": "./dist/preact-router.js"
 		},
 		"./package.json": "./package.json",
 		"./match": {
-			"module": "./match/index.mjs",
+			"module": "./match/index.module.js",
 			"import": "./match/index.mjs",
 			"require": "./match/index.js"
 		},
 		"./match/package.json": "./match/package.json"
 	},
 	"scripts": {
-		"build": "microbundle -f es --no-generateTypes && microbundle src/cjs.js -f cjs,umd --no-generateTypes && (cd match && npm run build)",
+		"build": "microbundle -f es --no-generateTypes && copyfiles dist/preact-router.module.js dist/preact-router.mjs && microbundle src/cjs.js -f cjs,umd --no-generateTypes && (cd match && npm run build && copyfiles index.module.js index.mjs)",
 		"test": "npm-run-all lint build test:unit test:ts",
 		"lint": "eslint src test",
 		"fix": "npm run lint -- --fix",

--- a/package.json
+++ b/package.json
@@ -10,20 +10,21 @@
 	"unpkg": "dist/preact-router.umd.js",
 	"exports": {
 		".": {
-			"module": "./dist/preact-router.module.js",
+			"module": "./dist/preact-router.mjs",
 			"import": "./dist/preact-router.mjs",
 			"require": "./dist/preact-router.js"
 		},
 		"./package.json": "./package.json",
 		"./match": {
-			"module": "./match/index.module.js",
+			"module": "./match/index.mjs",
 			"import": "./match/index.mjs",
 			"require": "./match/index.js"
 		},
 		"./match/package.json": "./match/package.json"
 	},
 	"scripts": {
-		"build": "microbundle -f es --no-generateTypes && copyfiles dist/preact-router.module.js dist/preact-router.mjs && microbundle src/cjs.js -f cjs,umd --no-generateTypes && (cd match && npm run build && copyfiles index.module.js index.mjs)",
+		"build": "microbundle -f es --no-generateTypes && microbundle src/cjs.js -f cjs,umd --no-generateTypes && (cd match && npm run build)",
+		"postbuild": "cp dist/preact-router.module.js dist/preact-router.mjs && cp match/index.module.js match/index.mjs",
 		"test": "npm-run-all lint build test:unit test:ts",
 		"lint": "eslint src test",
 		"fix": "npm run lint -- --fix",

--- a/package.json
+++ b/package.json
@@ -4,20 +4,20 @@
 	"version": "4.0.1",
 	"description": "Connect your components up to that address bar.",
 	"main": "dist/preact-router.js",
-	"module": "dist/preact-router.module.js",
-	"jsnext:main": "dist/preact-router.module.js",
+	"module": "dist/preact-router.mjs",
+	"jsnext:main": "dist/preact-router.mjs",
 	"umd:main": "dist/preact-router.umd.js",
 	"unpkg": "dist/preact-router.umd.js",
 	"exports": {
 		".": {
-			"module": "./dist/preact-router.module.js",
-			"import": "./dist/preact-router.module.js",
+			"module": "./dist/preact-router.mjs",
+			"import": "./dist/preact-router.mjs",
 			"require": "./dist/preact-router.js"
 		},
 		"./package.json": "./package.json",
 		"./match": {
-			"module": "./match/index.module.js",
-			"import": "./match/index.module.js",
+			"module": "./match/index.mjs",
+			"import": "./match/index.mjs",
 			"require": "./match/index.js"
 		},
 		"./match/package.json": "./match/package.json"

--- a/test/dist.test.js
+++ b/test/dist.test.js
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import { toBeCloneOf } from './utils/assert-clone-of';
 // import '../test_helpers/assert-clone-of';
 
-const router = require('../dist/preact-router');
+const router = require('../dist/preact-router.js');
 const { Router, Link, route } = router;
 
 describe('dist', () => {


### PR DESCRIPTION
Currently, preact-router fails to load in Node.js when it is imported from an ES module. Node correctly picks up the `.module.js` version as specified in the exports map, but loads it as cjs module because of the file extension. Here is a simple [StackBlitz example](https://stackblitz.com/edit/node-1zkqvl?file=index.js) that shows the current behavior.

This PR fixes the problem by changing the file extension to `.mjs`.