### PR TITLE
fix: fix #432 to support signals

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,9 +17,8 @@ export interface CustomHistory {
 	replace(path: string): void;
 }
 
-export interface RoutableProps {
+export interface RoutableProps extends Pick<HTMLAttributes<HTMLElement>, 'default'> {
 	path?: string;
-	default?: boolean;
 }
 
 export interface RouterOnChangeArgs<


### PR DESCRIPTION
## Problem

TypeScript compiler complains on the type conflict after signal support in Preact's type.

See #432 for more details.

## Solution

1. Extend `RoutableProps` by picking native HTML `default` attribute