### PR TITLE
Update Router and Link type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,11 +22,10 @@ export interface RoutableProps {
 	default?: boolean;
 }
 
+type DefaultParams = Record<string, string | undefined> | null;
+
 export interface RouterOnChangeArgs<
-	RouteParams extends Record<string, string | undefined> | null = Record<
-		string,
-		string | undefined
-	> | null
+	RouteParams extends DefaultParams = DefaultParams
 > {
 	router: Router;
 	url: string;
@@ -37,12 +36,8 @@ export interface RouterOnChangeArgs<
 	matches: RouteParams;
 }
 
-export interface RouterProps<
-	RouteParams extends Record<string, string | undefined> | null = Record<
-		string,
-		string | undefined
-	> | null
-> extends RoutableProps {
+export interface RouterProps<RouteParams extends DefaultParams = DefaultParams>
+	extends RoutableProps {
 	history?: CustomHistory;
 	static?: boolean;
 	url?: string;
@@ -72,22 +67,14 @@ export function Route<Props>(
 	props: RouteProps<Props> & Partial<Props>
 ): preact.VNode;
 
-export function Link(
-	props: { activeClassName?: string } & preact.JSX.HTMLAttributes
-): preact.VNode;
+export interface LinkProps
+	extends Omit<preact.JSX.HTMLAttributes<HTMLAnchorElement>, 'onClick'> {}
+
+export function Link(props: LinkProps): preact.VNode;
 
 export function useRouter<
-	RouteParams extends Record<string, string | undefined> | null = Record<
-		string,
-		string | undefined
-	> | null
->(): [
-	RouterOnChangeArgs<RouteParams>,
-	(
-		urlOrOptions: string | { url: string; replace?: boolean },
-		replace?: boolean
-	) => boolean
-];
+	RouteParams extends DefaultParams = DefaultParams
+>(): [RouterOnChangeArgs<RouteParams>, typeof route];
 
 declare module 'preact' {
 	export interface Attributes extends RoutableProps {}

--- a/match/index.d.ts
+++ b/match/index.d.ts
@@ -1,14 +1,15 @@
 import * as preact from 'preact';
 
-import { Link as StaticLink, RoutableProps } from '..';
+import { LinkProps as StaticLinkProps, RoutableProps } from '..';
 
 export class Match extends preact.Component<RoutableProps, {}> {
 	render(): preact.VNode;
 }
 
-export interface LinkProps extends preact.JSX.HTMLAttributes {
+export interface LinkProps extends StaticLinkProps {
+	activeClass?: string;
 	activeClassName?: string;
-	children?: preact.ComponentChildren;
+	path?: string;
 }
 
 export function Link(props: LinkProps): preact.VNode;

--- a/test/match.tsx
+++ b/test/match.tsx
@@ -1,6 +1,5 @@
 import { h } from 'preact';
-import { Link, RoutableProps } from '../';
-import { Match } from '../match';
+import { Match, Link } from '../match';
 
 function ChildComponent({}: {}) {
 	return <div></div>;
@@ -11,6 +10,10 @@ function LinkComponent({}: {}) {
 		<div>
 			<Link href="/a" />
 			<Link activeClassName="active" href="/b" />
+			<Link activeClass="active" href="/c">
+				This is some text
+			</Link>
+			<Link path="d" />
 		</div>
 	);
 }

--- a/test/router.tsx
+++ b/test/router.tsx
@@ -1,5 +1,5 @@
-import { h, render, Component, FunctionalComponent } from 'preact';
-import Router, { Route, RoutableProps, useRouter } from '../';
+import { h, Component, FunctionalComponent } from 'preact';
+import Router, { Link, Route, useRouter } from '../';
 
 class ClassComponent extends Component<{}, {}> {
 	render() {
@@ -10,6 +10,17 @@ class ClassComponent extends Component<{}, {}> {
 const SomeFunctionalComponent: FunctionalComponent<{}> = ({}) => {
 	return <div></div>;
 };
+
+function LinkComponent({}: {}) {
+	return (
+		<div>
+			<Link href="/a" />
+			<Link class="link" href="/b">
+				This is some text
+			</Link>
+		</div>
+	);
+}
 
 function RouterWithComponents() {
 	return (


### PR DESCRIPTION
This PR modifies the type definitions to `Router` and `Link` in order to better represent their actual implmentations.

The type definitions for the `Link` component in `preact-router` and `preact-router/match` have some ambiguity between each other, which causes problems like #379. The base `Link` type definition is now more restricted to make clear that `activeClassName` can only be applied to the `match` variant.

`onClick` is also now omitted as a link prop in order to ensure that the `onClick` handler used by `preact-router` is not overriden.

The `match` `Link` variant can also now take in extra props of `activeClass` and `path`.
