### PR TITLE
rm type for `default` attribute

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,6 @@ export interface CustomHistory {
 
 export interface RoutableProps {
 	path?: string;
-	default?: boolean;
 }
 
 export interface RouterOnChangeArgs<


### PR DESCRIPTION
This is an attempted fix for this issue on the main preact project:

https://github.com/preactjs/preact/issues/3934

New versions of preact include `SignalLike<boolean>` as a valid type for the `default` attribute. It was suggested by a preact maintainer that the `default` value defined here is unnecessary, as it should match what is provided by preact.