### PR TITLE
fix: `index.d.ts` does not show that "exec" is exported.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,8 @@ import * as preact from 'preact';
 export function route(url: string, replace?: boolean): boolean;
 export function route(options: { url: string; replace?: boolean }): boolean;
 
+export function exec(url: string, route: string, opts: { default?: boolean }): boolean;
+
 export function getCurrentUrl(): string;
 
 export interface Location {


### PR DESCRIPTION
`index.d.ts` does not show that "exec" is exported.

Heres where it's exported: https://github.com/preactjs/preact-router/blob/0401c31559be55d8a15aaf513aa7a941a766f42b/src/index.js#L275