### PR TITLE
Add types to package.json exports mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,17 +10,17 @@
 	"unpkg": "dist/preact-router.umd.js",
 	"exports": {
 		".": {
+			"types": "./index.d.ts",
 			"module": "./dist/preact-router.mjs",
 			"import": "./dist/preact-router.mjs",
-			"require": "./dist/preact-router.js",
-			"types": "./index.d.ts"
+			"require": "./dist/preact-router.js"
 		},
 		"./package.json": "./package.json",
 		"./match": {
+			"types": "./match/index.d.ts",
 			"module": "./match/index.mjs",
 			"import": "./match/index.mjs",
-			"require": "./match/index.js",
-			"types": "./match/index.d.ts"
+			"require": "./match/index.js"
 		},
 		"./match/package.json": "./match/package.json"
 	},

--- a/package.json
+++ b/package.json
@@ -12,13 +12,15 @@
 		".": {
 			"module": "./dist/preact-router.mjs",
 			"import": "./dist/preact-router.mjs",
-			"require": "./dist/preact-router.js"
+			"require": "./dist/preact-router.js",
+			"types": "./index.d.ts"
 		},
 		"./package.json": "./package.json",
 		"./match": {
 			"module": "./match/index.mjs",
 			"import": "./match/index.mjs",
-			"require": "./match/index.js"
+			"require": "./match/index.js",
+			"types": "./match/index.d.ts"
 		},
 		"./match/package.json": "./match/package.json"
 	},


### PR DESCRIPTION
Currently, preact-router errors when in TypeScripts config the moduleResolution is "bundler", "Node16" or "NodeNext". See example of error message here: https://github.com/preactjs/preact-router/issues/443

One proposed fix is to include types in the package.json's exports mapping. See example here: https://github.com/preactjs/preact-router/issues/429

This proposed fix is implemented in this pull request. If this is not a reasonable fix, some other fix should be introduced.

Related: https://github.com/microsoft/TypeScript/issues/52363