### PR TITLE
Pass generic to HTMLAttributes in Link typings

### DIFF
--- a/match/index.d.ts
+++ b/match/index.d.ts
@@ -6,7 +6,7 @@ export class Match extends preact.Component<RoutableProps, {}> {
 	render(): preact.VNode;
 }
 
-export interface LinkProps extends preact.JSX.HTMLAttributes {
+export interface LinkProps extends preact.JSX.HTMLAttributes<HTMLAnchorElement> {
 	activeClassName?: string;
 	children?: preact.ComponentChildren;
 }


### PR DESCRIPTION
Seems to fix type errors with event listeners