### PR TITLE
Correct some issues with TS typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import * as preact from 'preact';
 export function route(url: string, replace?: boolean): boolean;
 export function route(options: { url: string; replace?: boolean }): boolean;
 
-export function exec(url: string, route: string, opts: { default?: boolean }): boolean;
+export function exec(url: string, route: string, opts: { default?: boolean }): false | Record<string, string | undefined>;
 
 export function getCurrentUrl(): string;
 
@@ -53,11 +53,6 @@ export interface RouterProps<
 
 export class Router extends preact.Component<RouterProps, {}> {
 	canRoute(url: string): boolean;
-	getMatchingChildren(
-		children: preact.VNode[],
-		url: string,
-		invoke: boolean
-	): preact.VNode[];
 	routeTo(url: string): boolean;
 	render(props: RouterProps, {}): preact.VNode;
 }
@@ -75,7 +70,7 @@ export function Route<Props>(
 ): preact.VNode;
 
 export function Link(
-	props: { activeClassName?: string } & preact.JSX.HTMLAttributes
+	props: preact.JSX.HTMLAttributes<HTMLAnchorElement>
 ): preact.VNode;
 
 export function useRouter<

--- a/test/match.tsx
+++ b/test/match.tsx
@@ -1,6 +1,5 @@
 import { h } from 'preact';
-import { Link, RoutableProps } from '../';
-import { Match } from '../match';
+import { Link, Match } from '../match';
 
 function ChildComponent({}: {}) {
 	return <div></div>;


### PR DESCRIPTION
- `exec` seems to return an object, not `true`
- `getMatchingChildren` no longer exists
- `Link` in the root doesn't have `activeClassName` handling, and should have a generic parameter on HTMLAttributes (see also #445)