### PR TITLE
Add support for History API: state

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,11 +35,11 @@ function useRouter() {
 	return [ctx, route];
 }
 
-function setUrl(url, type = 'push') {
+function setUrl(url, type = 'push', state) {
 	if (customHistory && customHistory[type]) {
-		customHistory[type](url);
+		customHistory[type](url, state);
 	} else if (typeof history !== 'undefined' && history[`${type}State`]) {
-		history[`${type}State`](null, null, url);
+		history[`${type}State`](state, null, url);
 	}
 }
 
@@ -55,7 +55,7 @@ function getCurrentUrl() {
 	return `${url.pathname || ''}${url.search || ''}`;
 }
 
-function route(url, replace = false) {
+function route(url, replace = false, state = null) {
 	if (typeof url !== 'string' && url.url) {
 		replace = url.replace;
 		url = url.url;
@@ -63,7 +63,7 @@ function route(url, replace = false) {
 
 	// only push URL into history if we can handle it
 	if (canRoute(url)) {
-		setUrl(url, replace ? 'replace' : 'push');
+		setUrl(url, replace ? 'replace' : 'push', state);
 	}
 
 	return routeTo(url);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -117,7 +117,7 @@ describe('preact-router', () => {
 			);
 		});
 
-		it('should support custom history', () => {
+		it('should support custom history with state', () => {
 			let push = jasmine.createSpy('push');
 			let replace = jasmine.createSpy('replace');
 			let listen = jasmine.createSpy('listen');
@@ -149,11 +149,16 @@ describe('preact-router', () => {
 
 			route('/foo');
 			expect(push).toHaveBeenCalledTimes(1);
-			expect(push).toHaveBeenCalledWith('/foo');
+			expect(push).toHaveBeenCalledWith('/foo', null);
+
+			push.calls.reset();
+			route('/foo', false, { foo: 'bar' });
+			expect(push).toHaveBeenCalledTimes(1);
+			expect(push).toHaveBeenCalledWith('/foo', { foo: 'bar' });
 
 			route('/bar', true);
 			expect(replace).toHaveBeenCalledTimes(1);
-			expect(replace).toHaveBeenCalledWith('/bar');
+			expect(replace).toHaveBeenCalledWith('/bar', null);
 
 			router.componentWillUnmount();
 		});


### PR DESCRIPTION
Hi,

This PR adds support for [History API State](https://developer.mozilla.org/en-US/docs/Web/API/History/state).

Passed state can be read with `window.history.state`. It's useful to pass data between pages without needing a global state.