### PR TITLE
chore: Bump some devdeps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ export interface CustomHistory {
 
 export interface RoutableProps {
 	path?: string;
-	default?: boolean;
+	default?: boolean | preact.JSX.SignalLike<boolean | undefined>;
 }
 
 export interface RouterOnChangeArgs<

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
 	"name": "preact-router",
-	"version": "4.0.1",
+	"version": "4.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "preact-router",
-			"version": "4.0.1",
+			"version": "4.1.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@babel/plugin-transform-react-jsx": "^7.9.1",
 				"@types/jasmine": "^3.10.3",
-				"chai": "^3.5.0",
-				"copyfiles": "^1.0.0",
+				"chai": "^4.3.7",
 				"eslint": "^6.8.0",
 				"eslint-config-preact": "^1.1.1",
 				"history": "^5.2.0",
@@ -20,16 +19,13 @@
 				"karmatic": "^2.1.0",
 				"lint-staged": "^11.1.2",
 				"microbundle": "^0.14.2",
-				"mkdirp": "^0.5.3",
 				"mocha": "^5.2.0",
-				"npm-merge-driver-install": "^1.1.1",
 				"npm-run-all": "^3.0.0",
-				"preact": "^10.6.4",
+				"preact": "^10.16.0",
 				"prettier": "^2.3.2",
-				"rimraf": "^2.5.1",
 				"sinon": "^7.1.0",
-				"sinon-chai": "^2.8.0",
-				"typescript": "^3.4.4",
+				"sinon-chai": "^3.7.0",
+				"typescript": "^4.9.5",
 				"webpack": "^4.42.0"
 			},
 			"peerDependencies": {
@@ -2660,15 +2656,6 @@
 				"type-detect": "4.0.8"
 			}
 		},
-		"node_modules/@sinonjs/commons/node_modules/type-detect": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/@sinonjs/formatio": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
@@ -5184,17 +5171,21 @@
 			}
 		},
 		"node_modules/chai": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-			"integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+			"integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
 			"dev": true,
 			"dependencies": {
-				"assertion-error": "^1.0.1",
-				"deep-eql": "^0.1.3",
-				"type-detect": "^1.0.0"
+				"assertion-error": "^1.1.0",
+				"check-error": "^1.0.2",
+				"deep-eql": "^4.1.2",
+				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
+				"pathval": "^1.1.1",
+				"type-detect": "^4.0.5"
 			},
 			"engines": {
-				"node": ">= 0.4.0"
+				"node": ">=4"
 			}
 		},
 		"node_modules/chalk": {
@@ -5244,6 +5235,15 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
+		},
+		"node_modules/check-error": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+			"integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
 		},
 		"node_modules/chokidar": {
 			"version": "3.5.2",
@@ -5312,12 +5312,6 @@
 			"engines": {
 				"node": ">=6.0"
 			}
-		},
-		"node_modules/ci-info": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
-			"dev": true
 		},
 		"node_modules/cipher-base": {
 			"version": "1.0.4",
@@ -5840,24 +5834,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/copyfiles": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-1.2.0.tgz",
-			"integrity": "sha1-qNo6xBqiIgrim9PFi2mEKU8sWTw=",
-			"dev": true,
-			"dependencies": {
-				"glob": "^7.0.5",
-				"ltcdr": "^2.2.1",
-				"minimatch": "^3.0.3",
-				"mkdirp": "^0.5.1",
-				"noms": "0.0.0",
-				"through2": "^2.0.1"
-			},
-			"bin": {
-				"copyfiles": "copyfiles",
-				"copyup": "copyup"
 			}
 		},
 		"node_modules/core-js": {
@@ -6498,24 +6474,15 @@
 			}
 		},
 		"node_modules/deep-eql": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-			"integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+			"integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
 			"dev": true,
 			"dependencies": {
-				"type-detect": "0.1.1"
+				"type-detect": "^4.0.0"
 			},
 			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/deep-eql/node_modules/type-detect": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-			"integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-			"dev": true,
-			"engines": {
-				"node": "*"
+				"node": ">=6"
 			}
 		},
 		"node_modules/deep-is": {
@@ -8473,12 +8440,6 @@
 				"semver": "bin/semver.js"
 			}
 		},
-		"node_modules/find-root": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-			"dev": true
-		},
 		"node_modules/find-up": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -8728,6 +8689,15 @@
 			"dev": true,
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-func-name": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+			"integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+			"dev": true,
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/get-intrinsic": {
@@ -9789,18 +9759,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-ci": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-			"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-			"dev": true,
-			"dependencies": {
-				"ci-info": "^1.5.0"
-			},
-			"bin": {
-				"is-ci": "bin.js"
 			}
 		},
 		"node_modules/is-core-module": {
@@ -11964,6 +11922,15 @@
 				"loose-envify": "cli.js"
 			}
 		},
+		"node_modules/loupe": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+			"integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+			"dev": true,
+			"dependencies": {
+				"get-func-name": "^2.0.0"
+			}
+		},
 		"node_modules/lower-case": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -11996,15 +11963,6 @@
 			"dependencies": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
-			}
-		},
-		"node_modules/ltcdr": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ltcdr/-/ltcdr-2.2.1.tgz",
-			"integrity": "sha1-Wrh60dTB2rjowIu/A37gwZAih88=",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6.x"
 			}
 		},
 		"node_modules/magic-string": {
@@ -12260,6 +12218,20 @@
 				"microbundle": "dist/cli.js"
 			}
 		},
+		"node_modules/microbundle/node_modules/acorn": {
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+			"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/microbundle/node_modules/camelcase": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -12335,19 +12307,6 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
 			"dev": true
-		},
-		"node_modules/microbundle/node_modules/typescript": {
-			"version": "4.5.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-			"integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
-			"dev": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
-			}
 		},
 		"node_modules/micromatch": {
 			"version": "3.1.10",
@@ -12920,40 +12879,6 @@
 			"integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
 			"dev": true
 		},
-		"node_modules/noms": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
-			"integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.1",
-				"readable-stream": "~1.0.31"
-			}
-		},
-		"node_modules/noms/node_modules/isarray": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-			"dev": true
-		},
-		"node_modules/noms/node_modules/readable-stream": {
-			"version": "1.0.34",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-			"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-			"dev": true,
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.1",
-				"isarray": "0.0.1",
-				"string_decoder": "~0.10.x"
-			}
-		},
-		"node_modules/noms/node_modules/string_decoder": {
-			"version": "0.10.31",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-			"dev": true
-		},
 		"node_modules/normalize-package-data": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -13014,552 +12939,6 @@
 			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-merge-driver": {
-			"version": "2.3.5",
-			"resolved": "https://registry.npmjs.org/npm-merge-driver/-/npm-merge-driver-2.3.5.tgz",
-			"integrity": "sha512-MUxE26ZdDWAc+wlqwyOEIhRH1EdaIXCWSZbqAQ76dUkz3uSrxrLhfgQ3nb3oZbqC5e4NyLcCdzTSDVwkisoJpg==",
-			"bundleDependencies": [
-				"yargs",
-				"mkdirp"
-			],
-			"dev": true,
-			"dependencies": {
-				"mkdirp": "^0.5.1",
-				"yargs": "^10.0.3"
-			},
-			"bin": {
-				"npm-merge-driver": "index.js"
-			}
-		},
-		"node_modules/npm-merge-driver-install": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/npm-merge-driver-install/-/npm-merge-driver-install-1.1.1.tgz",
-			"integrity": "sha512-QoEoJ1SAkkVPoZ9p84yel5xiMeXXqpkw1KwA8hP0iVO/NWZUYYgTUkXRL54YJ7HyLK3aTaiQrRVfpPpb9Cm/FA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"find-root": "^1.1.0",
-				"is-ci": "^1.2.0",
-				"npm-merge-driver": "^2.3.5"
-			},
-			"bin": {
-				"npm-merge-driver-install": "index.js"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/ansi-regex": {
-			"version": "2.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/code-point-at": {
-			"version": "1.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/cross-spawn": {
-			"version": "5.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"lru-cache": "^4.0.1",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/decamelize": {
-			"version": "1.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/execa": {
-			"version": "0.7.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/find-up": {
-			"version": "2.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"locate-path": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/get-caller-file": {
-			"version": "1.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
-		},
-		"node_modules/npm-merge-driver/node_modules/get-stream": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/invert-kv": {
-			"version": "1.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/is-fullwidth-code-point": {
-			"version": "1.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"number-is-nan": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/is-stream": {
-			"version": "1.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/isexe": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
-		},
-		"node_modules/npm-merge-driver/node_modules/lcid": {
-			"version": "1.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"invert-kv": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/locate-path": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/lru-cache": {
-			"version": "4.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/mem": {
-			"version": "1.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"mimic-fn": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/mimic-fn": {
-			"version": "1.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/minimist": {
-			"version": "0.0.8",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/npm-merge-driver/node_modules/mkdirp": {
-			"version": "0.5.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"minimist": "0.0.8"
-			},
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/npm-run-path": {
-			"version": "2.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"path-key": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/number-is-nan": {
-			"version": "1.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/os-locale": {
-			"version": "2.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"execa": "^0.7.0",
-				"lcid": "^1.0.0",
-				"mem": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/p-finally": {
-			"version": "1.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/p-limit": {
-			"version": "1.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/p-locate": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-limit": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/path-exists": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/path-key": {
-			"version": "2.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/pseudomap": {
-			"version": "1.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
-		},
-		"node_modules/npm-merge-driver/node_modules/require-directory": {
-			"version": "2.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/require-main-filename": {
-			"version": "1.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
-		},
-		"node_modules/npm-merge-driver/node_modules/set-blocking": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
-		},
-		"node_modules/npm-merge-driver/node_modules/shebang-command": {
-			"version": "1.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"shebang-regex": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/shebang-regex": {
-			"version": "1.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/signal-exit": {
-			"version": "3.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
-		},
-		"node_modules/npm-merge-driver/node_modules/string-width": {
-			"version": "1.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"code-point-at": "^1.0.0",
-				"is-fullwidth-code-point": "^1.0.0",
-				"strip-ansi": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/strip-ansi": {
-			"version": "3.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/strip-eof": {
-			"version": "1.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/which": {
-			"version": "1.3.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"which": "bin/which"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/which-module": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
-		},
-		"node_modules/npm-merge-driver/node_modules/wrap-ansi": {
-			"version": "2.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/y18n": {
-			"version": "3.2.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
-		},
-		"node_modules/npm-merge-driver/node_modules/yallist": {
-			"version": "2.1.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
-		},
-		"node_modules/npm-merge-driver/node_modules/yargs": {
-			"version": "10.0.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^3.2.0",
-				"decamelize": "^1.1.1",
-				"find-up": "^2.1.0",
-				"get-caller-file": "^1.0.1",
-				"os-locale": "^2.0.0",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^1.0.1",
-				"set-blocking": "^2.0.0",
-				"string-width": "^2.0.0",
-				"which-module": "^2.0.0",
-				"y18n": "^3.2.1",
-				"yargs-parser": "^8.0.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/yargs-parser": {
-			"version": "8.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"camelcase": "^4.1.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/yargs-parser/node_modules/camelcase": {
-			"version": "4.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/yargs/node_modules/ansi-regex": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/yargs/node_modules/cliui": {
-			"version": "3.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wrap-ansi": "^2.0.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/yargs/node_modules/cliui/node_modules/string-width": {
-			"version": "1.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"code-point-at": "^1.0.0",
-				"is-fullwidth-code-point": "^1.0.0",
-				"strip-ansi": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/yargs/node_modules/string-width": {
-			"version": "2.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/yargs/node_modules/string-width/node_modules/is-fullwidth-code-point": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-merge-driver/node_modules/yargs/node_modules/string-width/node_modules/strip-ansi": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^3.0.0"
-			},
 			"engines": {
 				"node": ">=4"
 			}
@@ -14216,6 +13595,15 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/pathval": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+			"dev": true,
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/pause-stream": {
@@ -14925,9 +14313,9 @@
 			"dev": true
 		},
 		"node_modules/preact": {
-			"version": "10.6.4",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.6.4.tgz",
-			"integrity": "sha512-WyosM7pxGcndU8hY0OQlLd54tOU+qmG45QXj2dAYrL11HoyU/EzOSTlpJsirbBr1QW7lICxSsVJJmcmUglovHQ==",
+			"version": "10.16.0",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.16.0.tgz",
+			"integrity": "sha512-XTSj3dJ4roKIC93pald6rWuB2qQJO9gO2iLLyTe87MrjQN+HklueLsmskbywEWqCHlclgz3/M4YLL2iBr9UmMA==",
 			"dev": true,
 			"funding": {
 				"type": "opencollective",
@@ -15952,6 +15340,20 @@
 				"rollup": "^2.0.0"
 			}
 		},
+		"node_modules/rollup-plugin-terser/node_modules/acorn": {
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+			"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/rollup-plugin-terser/node_modules/serialize-javascript": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
@@ -16481,13 +15883,13 @@
 			}
 		},
 		"node_modules/sinon-chai": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
-			"integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+			"integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
 			"dev": true,
 			"peerDependencies": {
-				"chai": ">=1.9.2 <5",
-				"sinon": "^1.4.0 || ^2.1.0 || ^3.0.0 || ^4.0.0"
+				"chai": "^4.0.0",
+				"sinon": ">=4.0.0"
 			}
 		},
 		"node_modules/sinon/node_modules/supports-color": {
@@ -18019,12 +17421,12 @@
 			}
 		},
 		"node_modules/type-detect": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-			"integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true,
 			"engines": {
-				"node": "*"
+				"node": ">=4"
 			}
 		},
 		"node_modules/type-fest": {
@@ -18056,9 +17458,9 @@
 			"dev": true
 		},
 		"node_modules/typescript": {
-			"version": "3.7.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-			"integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -21804,14 +21206,6 @@
 			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
-			},
-			"dependencies": {
-				"type-detect": {
-					"version": "4.0.8",
-					"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-					"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-					"dev": true
-				}
 			}
 		},
 		"@sinonjs/formatio": {
@@ -23897,14 +23291,18 @@
 			}
 		},
 		"chai": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-			"integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+			"integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
 			"dev": true,
 			"requires": {
-				"assertion-error": "^1.0.1",
-				"deep-eql": "^0.1.3",
-				"type-detect": "^1.0.0"
+				"assertion-error": "^1.1.0",
+				"check-error": "^1.0.2",
+				"deep-eql": "^4.1.2",
+				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
+				"pathval": "^1.1.1",
+				"type-detect": "^4.0.5"
 			}
 		},
 		"chalk": {
@@ -23952,6 +23350,12 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+			"dev": true
+		},
+		"check-error": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+			"integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
 			"dev": true
 		},
 		"chokidar": {
@@ -24009,12 +23413,6 @@
 			"requires": {
 				"tslib": "^1.9.0"
 			}
-		},
-		"ci-info": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
-			"dev": true
 		},
 		"cipher-base": {
 			"version": "1.0.4",
@@ -24456,20 +23854,6 @@
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
-		},
-		"copyfiles": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-1.2.0.tgz",
-			"integrity": "sha1-qNo6xBqiIgrim9PFi2mEKU8sWTw=",
-			"dev": true,
-			"requires": {
-				"glob": "^7.0.5",
-				"ltcdr": "^2.2.1",
-				"minimatch": "^3.0.3",
-				"mkdirp": "^0.5.1",
-				"noms": "0.0.0",
-				"through2": "^2.0.1"
-			}
 		},
 		"core-js": {
 			"version": "2.6.11",
@@ -24969,20 +24353,12 @@
 			}
 		},
 		"deep-eql": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-			"integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+			"integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
 			"dev": true,
 			"requires": {
-				"type-detect": "0.1.1"
-			},
-			"dependencies": {
-				"type-detect": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-					"integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-					"dev": true
-				}
+				"type-detect": "^4.0.0"
 			}
 		},
 		"deep-is": {
@@ -26535,12 +25911,6 @@
 				}
 			}
 		},
-		"find-root": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-			"dev": true
-		},
 		"find-up": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -26733,6 +26103,12 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true
+		},
+		"get-func-name": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+			"integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
 			"dev": true
 		},
 		"get-intrinsic": {
@@ -27563,15 +26939,6 @@
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
 			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
 			"dev": true
-		},
-		"is-ci": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-			"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-			"dev": true,
-			"requires": {
-				"ci-info": "^1.5.0"
-			}
 		},
 		"is-core-module": {
 			"version": "2.8.0",
@@ -29248,6 +28615,15 @@
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
+		"loupe": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+			"integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+			"dev": true,
+			"requires": {
+				"get-func-name": "^2.0.0"
+			}
+		},
 		"lower-case": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -29280,12 +28656,6 @@
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
 			}
-		},
-		"ltcdr": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ltcdr/-/ltcdr-2.2.1.tgz",
-			"integrity": "sha1-Wrh60dTB2rjowIu/A37gwZAih88=",
-			"dev": true
 		},
 		"magic-string": {
 			"version": "0.25.7",
@@ -29503,6 +28873,14 @@
 				"typescript": "^4.1.3"
 			},
 			"dependencies": {
+				"acorn": {
+					"version": "8.10.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+					"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+					"dev": true,
+					"optional": true,
+					"peer": true
+				},
 				"camelcase": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -29545,12 +28923,6 @@
 					"version": "2.3.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
 					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-					"dev": true
-				},
-				"typescript": {
-					"version": "4.5.4",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-					"integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
 					"dev": true
 				}
 			}
@@ -30050,42 +29422,6 @@
 			"integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
 			"dev": true
 		},
-		"noms": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
-			"integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"readable-stream": "~1.0.31"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				}
-			}
-		},
 		"normalize-package-data": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -30132,392 +29468,6 @@
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
 				}
-			}
-		},
-		"npm-merge-driver": {
-			"version": "2.3.5",
-			"resolved": "https://registry.npmjs.org/npm-merge-driver/-/npm-merge-driver-2.3.5.tgz",
-			"integrity": "sha512-MUxE26ZdDWAc+wlqwyOEIhRH1EdaIXCWSZbqAQ76dUkz3uSrxrLhfgQ3nb3oZbqC5e4NyLcCdzTSDVwkisoJpg==",
-			"dev": true,
-			"requires": {
-				"mkdirp": "^0.5.1",
-				"yargs": "^10.0.3"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"cross-spawn": {
-					"version": "5.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"lru-cache": "^4.0.1",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"decamelize": {
-					"version": "1.2.0",
-					"bundled": true,
-					"dev": true
-				},
-				"execa": {
-					"version": "0.7.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
-				},
-				"find-up": {
-					"version": "2.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"get-caller-file": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"get-stream": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"invert-kv": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"is-stream": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"isexe": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"lcid": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"invert-kv": "^1.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"lru-cache": {
-					"version": "4.1.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
-				},
-				"mem": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^1.0.0"
-					}
-				},
-				"mimic-fn": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"minimist": {
-					"version": "0.0.8",
-					"bundled": true,
-					"dev": true
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"npm-run-path": {
-					"version": "2.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"path-key": "^2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"os-locale": {
-					"version": "2.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"execa": "^0.7.0",
-						"lcid": "^1.0.0",
-						"mem": "^1.1.0"
-					}
-				},
-				"p-finally": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"p-limit": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"path-key": {
-					"version": "2.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"pseudomap": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"require-directory": {
-					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
-				},
-				"require-main-filename": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"shebang-command": {
-					"version": "1.2.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"shebang-regex": "^1.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"strip-eof": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"which": {
-					"version": "1.3.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				},
-				"which-module": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"wrap-ansi": {
-					"version": "2.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
-					}
-				},
-				"y18n": {
-					"version": "3.2.1",
-					"bundled": true,
-					"dev": true
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"bundled": true,
-					"dev": true
-				},
-				"yargs": {
-					"version": "10.0.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^8.0.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "3.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"cliui": {
-							"version": "3.2.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"string-width": "^1.0.1",
-								"strip-ansi": "^3.0.1",
-								"wrap-ansi": "^2.0.0"
-							},
-							"dependencies": {
-								"string-width": {
-									"version": "1.0.2",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"code-point-at": "^1.0.0",
-										"is-fullwidth-code-point": "^1.0.0",
-										"strip-ansi": "^3.0.0"
-									}
-								}
-							}
-						},
-						"string-width": {
-							"version": "2.1.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-fullwidth-code-point": "^2.0.0",
-								"strip-ansi": "^4.0.0"
-							},
-							"dependencies": {
-								"is-fullwidth-code-point": {
-									"version": "2.0.0",
-									"bundled": true,
-									"dev": true
-								},
-								"strip-ansi": {
-									"version": "4.0.0",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"ansi-regex": "^3.0.0"
-									}
-								}
-							}
-						}
-					}
-				},
-				"yargs-parser": {
-					"version": "8.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"camelcase": "^4.1.0"
-					},
-					"dependencies": {
-						"camelcase": {
-							"version": "4.1.0",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				}
-			}
-		},
-		"npm-merge-driver-install": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/npm-merge-driver-install/-/npm-merge-driver-install-1.1.1.tgz",
-			"integrity": "sha512-QoEoJ1SAkkVPoZ9p84yel5xiMeXXqpkw1KwA8hP0iVO/NWZUYYgTUkXRL54YJ7HyLK3aTaiQrRVfpPpb9Cm/FA==",
-			"dev": true,
-			"requires": {
-				"find-root": "^1.1.0",
-				"is-ci": "^1.2.0",
-				"npm-merge-driver": "^2.3.5"
 			}
 		},
 		"npm-run-all": {
@@ -31043,6 +29993,12 @@
 				"pinkie-promise": "^2.0.0"
 			}
 		},
+		"pathval": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+			"dev": true
+		},
 		"pause-stream": {
 			"version": "0.0.11",
 			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
@@ -31511,9 +30467,9 @@
 			"dev": true
 		},
 		"preact": {
-			"version": "10.6.4",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.6.4.tgz",
-			"integrity": "sha512-WyosM7pxGcndU8hY0OQlLd54tOU+qmG45QXj2dAYrL11HoyU/EzOSTlpJsirbBr1QW7lICxSsVJJmcmUglovHQ==",
+			"version": "10.16.0",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.16.0.tgz",
+			"integrity": "sha512-XTSj3dJ4roKIC93pald6rWuB2qQJO9gO2iLLyTe87MrjQN+HklueLsmskbywEWqCHlclgz3/M4YLL2iBr9UmMA==",
 			"dev": true
 		},
 		"prelude-ls": {
@@ -32323,6 +31279,14 @@
 				"terser": "^5.0.0"
 			},
 			"dependencies": {
+				"acorn": {
+					"version": "8.10.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+					"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+					"dev": true,
+					"optional": true,
+					"peer": true
+				},
 				"serialize-javascript": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
@@ -32775,9 +31739,9 @@
 			}
 		},
 		"sinon-chai": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
-			"integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+			"integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
 			"dev": true,
 			"requires": {}
 		},
@@ -34026,9 +32990,9 @@
 			}
 		},
 		"type-detect": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-			"integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true
 		},
 		"type-fest": {
@@ -34054,9 +33018,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "3.7.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-			"integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
 			"dev": true
 		},
 		"ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -84,8 +84,7 @@
 	"devDependencies": {
 		"@babel/plugin-transform-react-jsx": "^7.9.1",
 		"@types/jasmine": "^3.10.3",
-		"chai": "^3.5.0",
-		"copyfiles": "^1.0.0",
+		"chai": "^4.3.7",
 		"eslint": "^6.8.0",
 		"eslint-config-preact": "^1.1.1",
 		"history": "^5.2.0",
@@ -93,16 +92,13 @@
 		"karmatic": "^2.1.0",
 		"lint-staged": "^11.1.2",
 		"microbundle": "^0.14.2",
-		"mkdirp": "^0.5.3",
 		"mocha": "^5.2.0",
-		"npm-merge-driver-install": "^1.1.1",
 		"npm-run-all": "^3.0.0",
-		"preact": "^10.6.4",
+		"preact": "^10.16.0",
 		"prettier": "^2.3.2",
-		"rimraf": "^2.5.1",
 		"sinon": "^7.1.0",
-		"sinon-chai": "^2.8.0",
-		"typescript": "^3.4.4",
+		"sinon-chai": "^3.7.0",
+		"typescript": "^4.9.5",
 		"webpack": "^4.42.0"
 	}
 }


### PR DESCRIPTION
Bumps some deps to (hopefully) fix the CI issues:

 - `chai` & `sinon-chai`
   - Fixing conflicting peer deps
 - `preact`
   - Necessary to incorporate in `SignalLike` (see #452)
 - `typescript`
   - Necessary to support newer lib features that Preact ships (matched version to [preact repo](https://github.com/preactjs/preact/blob/5a56a830b6abf23009d7e2b5a0d0b7707a86a8e8/package.json#L308))
 - `copyfiles`, `mkdirp`, `rimraf`, `npm-merge-driver-install`
   - Seem to all be legacy & unused   