### PR TITLE
4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "preact-router",
 	"amdName": "preactRouter",
-	"version": "4.1.1",
+	"version": "4.1.2",
 	"description": "Connect your components up to that address bar.",
 	"main": "dist/preact-router.js",
 	"module": "dist/preact-router.module.js",


### PR DESCRIPTION
## Fixes

- Types mismatch between `preact-router` and `preact` (#452, thanks @paulreece )