### PR TITLE
Update exportable props and function signature to Match

### DIFF
--- a/match/index.d.ts
+++ b/match/index.d.ts
@@ -2,7 +2,13 @@ import * as preact from 'preact';
 
 import { Link as StaticLink, RoutableProps } from '..';
 
-export class Match extends preact.Component<RoutableProps, {}> {
+export type MatchChildrenProps = {
+	matches: boolean;
+	url: string;
+	path: string;
+}
+
+export class Match extends preact.Component<RoutableProps & { children: (MatchChildrenProps) => preact.ComponentChildren }, {}> {
 	render(): preact.VNode;
 }
 


### PR DESCRIPTION
Deals with https://github.com/preactjs/preact-router/issues/458 & https://github.com/preactjs/preact-router/issues/456.

I've added a type definition for `<Match />`'s `children` function, along with an exportable type for the function's own props.