### PR TITLE
Don't make component's props in <Route /> wrapper optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,8 +65,12 @@ export interface RouteProps<Props> extends RoutableProps {
 	component: AnyComponent<Props>;
 }
 
+/**
+ * As route accepts additional props (`path` and `default`),
+ * it's better to avoid those props in your components.
+ */
 export function Route<Props>(
-	props: RouteProps<Props> & Partial<Props>
+	props: RouteProps<Props> & Props
 ): preact.VNode;
 
 export function Link(


### PR DESCRIPTION
Using TypeScript made me use `<Route />` wrapper, but it makes all the component's props optional. That kinda goes against the idea of using TypeScript in the first place.